### PR TITLE
Corrected PCM port number

### DIFF
--- a/src/main/java/robot/subsystems/HatchMechanism.java
+++ b/src/main/java/robot/subsystems/HatchMechanism.java
@@ -7,7 +7,7 @@ public class HatchMechanism {
     private DoubleSolenoid hatchSolenoid;
 
     public HatchMechanism() {
-        hatchSolenoid = new DoubleSolenoid(1, 0);
+        hatchSolenoid = new DoubleSolenoid(6, 1, 0);
     }
 
     public void place() {


### PR DESCRIPTION
Previous method uses default port number of 0 when the correct number is 6.